### PR TITLE
Bugfix/zoom reports

### DIFF
--- a/classes/task/get_meeting_reports.php
+++ b/classes/task/get_meeting_reports.php
@@ -166,24 +166,6 @@ class get_meeting_reports extends \core\task\scheduled_task {
         // Cleanup the name. For some reason # gets into the name instead of a comma.
         $participant->name = str_replace('#', ',', $participant->name);
 
-        // Try to see if we successfully queried for this user and found a Moodle id before.
-        if (!empty($participant->id)) {
-            // Sometimes uuid is blank from Zoom.
-            $participantmatches = $DB->get_records('zoom_meeting_participants',
-                    array('uuid' => $participant->id), null, 'id, userid, name');
-
-            if (!empty($participantmatches)) {
-                // Found some previous matches. Find first one with userid set.
-                foreach ($participantmatches as $participantmatch) {
-                    if (!empty($participantmatch->userid)) {
-                        $moodleuserid = $participantmatch->userid;
-                        $name = $participantmatch->name;
-                        break;
-                    }
-                }
-            }
-        }
-
         // Did not find a previous match.
         if (empty($moodleuserid)) {
             if (!empty($participant->user_email) && ($moodleuserid =

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2020072800;
-$plugin->release = 'v2.4.0';
+$plugin->version = 2020081800;
+$plugin->release = 'v2.4.1';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 900; // secs


### PR DESCRIPTION
We are removing the logic to match the user using zoom user UUID in already existing participant's report because once the zoom user UUID is saved with a particular name in the participant's report, then every other report will have the same participant name for the particular UUID which will create confusion.