### PR TITLE
Add/default zoom user registration off

### DIFF
--- a/lang/en/zoom.php
+++ b/lang/en/zoom.php
@@ -109,6 +109,7 @@ $string['on'] = 'On';
 $string['option_audio'] = 'Audio options';
 $string['option_host_video'] = 'Host video';
 $string['enable_registration'] = 'Registration';
+$string['enable_registration_switch'] = 'Registration switch';
 $string['add_meeting_registrant'] = "approve meeting registrants";
 $string['option_jbh'] = 'Enable join before host';
 $string['option_mute_upon_entry'] = 'Mute attendees upon entry';

--- a/mod_form.php
+++ b/mod_form.php
@@ -113,8 +113,8 @@ class mod_zoom_mod_form extends moodleform_mod {
 
         // Add user registration
         $mform->addElement('advcheckbox', 'enable_registration', 'Registration');
-        $mform->setDefault('enable_registration', $config->defacultregistrationtype);
-        if($config->defacultregistrationtype == 0) {
+        $mform->setDefault('enable_registration', $config->registrationswitch);
+        if($config->registrationswitch == 0) {
             $mform->disabledIf('enable_registration', 'webinar');
         }
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -111,11 +111,10 @@ class mod_zoom_mod_form extends moodleform_mod {
 
         $mform->addElement('advcheckbox', 'recurring', 'Recurring');
 
-        // Add user registration
-        $mform->addElement('advcheckbox', 'enable_registration', 'Registration');
-        $mform->setDefault('enable_registration', $config->registrationswitch);
-        if($config->registrationswitch == 0) {
-            $mform->disabledIf('enable_registration', 'webinar');
+        if($config->registrationswitch == 1) {
+            // Add user registration
+            $mform->addElement('advcheckbox', 'enable_registration', 'Registration');
+            $mform->setDefault('enable_registration', $config->registrationswitch);
         }
 
         // Repeat type

--- a/mod_form.php
+++ b/mod_form.php
@@ -114,6 +114,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         // Add user registration
         $mform->addElement('advcheckbox', 'enable_registration', 'Registration');
         $mform->setDefault('enable_registration', $config->defacultregistrationtype);
+        $mform->disabledIf('enable_registration', 'webinar', 'notchecked');
 
         // Repeat type
         $meeting_types = [

--- a/mod_form.php
+++ b/mod_form.php
@@ -114,7 +114,9 @@ class mod_zoom_mod_form extends moodleform_mod {
         // Add user registration
         $mform->addElement('advcheckbox', 'enable_registration', 'Registration');
         $mform->setDefault('enable_registration', $config->defacultregistrationtype);
-        $mform->disabledIf('enable_registration', 'webinar', 'notchecked');
+        if($config->defacultregistrationtype == 0) {
+            $mform->disabledIf('enable_registration', 'webinar');
+        }
 
         // Repeat type
         $meeting_types = [

--- a/settings.php
+++ b/settings.php
@@ -88,7 +88,7 @@ if ($ADMIN->fulltree) {
     $settings->add($defaultrecurring);
 
     $defacultregistrationtype = new admin_setting_configcheckbox('mod_zoom/defacultregistrationtype', get_string('enable_registration', 'zoom'), 
-            '', 1, 1, 1);
+            '', 1, 0, 1);
     $settings->add($defacultregistrationtype);
 
     $defaulthostvideo = new admin_setting_configcheckbox('mod_zoom/defaulthostvideo', get_string('option_host_video', 'zoom'),

--- a/settings.php
+++ b/settings.php
@@ -87,9 +87,9 @@ if ($ADMIN->fulltree) {
             get_string('recurringmeeting_help', 'zoom'), 0, 1, 0);
     $settings->add($defaultrecurring);
 
-    $defacultregistrationtype = new admin_setting_configcheckbox('mod_zoom/defacultregistrationtype', get_string('enable_registration', 'zoom'), 
+    $registrationswitch = new admin_setting_configcheckbox('mod_zoom/registrationswitch', get_string('enable_registration_switch', 'zoom'), 
             '', 1, 0, 1);
-    $settings->add($defacultregistrationtype);
+    $settings->add($registrationswitch);
 
     $defaulthostvideo = new admin_setting_configcheckbox('mod_zoom/defaulthostvideo', get_string('option_host_video', 'zoom'),
             '', 1, 1, 0);

--- a/settings.php
+++ b/settings.php
@@ -88,7 +88,7 @@ if ($ADMIN->fulltree) {
     $settings->add($defaultrecurring);
 
     $registrationswitch = new admin_setting_configcheckbox('mod_zoom/registrationswitch', get_string('enable_registration_switch', 'zoom'), 
-            '', 1, 0, 1);
+            '', 0, 1, 0);
     $settings->add($registrationswitch);
 
     $defaulthostvideo = new admin_setting_configcheckbox('mod_zoom/defaulthostvideo', get_string('option_host_video', 'zoom'),


### PR DESCRIPTION
**Overview**

1. In default zoom setting set registration as off.
2. If registration is set to off then disable the **registration checkbox** at zoom create meeting form
