### PR TITLE
Fix zoom activity error in moodle

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -128,7 +128,7 @@ class mod_zoom_webservice {
             'iss' => $this->apikey,
             'exp' => time() + 40
         );
-        $token = \Firebase\JWT\JWT::encode($payload, $this->apisecret);
+        $token = \Firebase\JWT\JWT::encode($payload, $this->apisecret, 'HS256');
         $curl->setHeader('Authorization: Bearer ' . $token);
         if ($method != 'get') {
             $curl->setHeader('Content-Type: application/json');


### PR DESCRIPTION
This PR is to fix error #41 

This error occurred because of missing 3rd argument in JWT::encode() method. 

Taking reference from [Zoom documention](https://marketplace.zoom.us/docs/guides/auth/jwt/)
I have set algo as **HS256**.