### PR TITLE
Add log statement to record fail scenario

### DIFF
--- a/classes/task/insert_recordings.php
+++ b/classes/task/insert_recordings.php
@@ -84,6 +84,8 @@ require_once($CFG->dirroot.'/mod/zoom/classes/webservice.php');
                         } else {
                             mtrace('No recordings found for the meeting_id: '. $value->meeting_id);
                         }
+                    } else {
+                        mtrace('Recording already exist for meeting: '. $value->meeting_id . 'and uuid: '. $uuid);
                     }
                 }
 


### PR DESCRIPTION
This PR add a separate else block to handle case when recording already existing.

Done this because in demo site while running cron task pauses at when recording already exists. 