### PR TITLE
Fix: Multiple recordings for a same meeting instance

### DIFF
--- a/classes/task/insert_recordings.php
+++ b/classes/task/insert_recordings.php
@@ -4,10 +4,10 @@ namespace mod_zoom\task;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->dirroot.'/mod/zoom/locallib.php');
-require_once($CFG->dirroot.'/lib/modinfolib.php');
-require_once($CFG->dirroot.'/mod/zoom/lib.php');
-require_once($CFG->dirroot.'/mod/zoom/classes/webservice.php');
+require_once($CFG->dirroot . '/mod/zoom/locallib.php');
+require_once($CFG->dirroot . '/lib/modinfolib.php');
+require_once($CFG->dirroot . '/mod/zoom/lib.php');
+require_once($CFG->dirroot . '/mod/zoom/classes/webservice.php');
 
 
 /**
@@ -15,14 +15,16 @@ require_once($CFG->dirroot.'/mod/zoom/classes/webservice.php');
  *
  * @package   mod_zoom
  */
- class insert_recordings extends \core\task\scheduled_task {
+class insert_recordings extends \core\task\scheduled_task
+{
 
     /**
      * Returns name of task.
      *
      * @return string
      */
-    public function get_name() {
+    public function get_name()
+    {
         return get_string("update_recording", "zoom");
     }
 
@@ -64,30 +66,39 @@ require_once($CFG->dirroot.'/mod/zoom/classes/webservice.php');
                         if (!$existing_recording) {
                             $recordings = $service->get_meeting_recording($uuid);
 
-                            if (!empty($recordings) && !empty($recordings->recording_files[0])) {
-                                //Get only the first recording file
-                                $rec = $recordings->recording_files[0];
-                                $record = new \stdClass();
-                                $record->meeting_id = $recordings->id;
-                                $record->uuid = $recordings->uuid;
-                                $record->play_url = $rec->play_url;
-                                $record->download_url = $rec->download_url . '?access_token=' . $recordings->download_access_token;
-                                $record->start_time = $rec->recording_start;
-                                $record->end_time = $rec->recording_end;
-                                $record->status = $rec->status;
-                                $zoom_recordings = $DB->insert_record('zoom_recordings', $record);
-                                if (is_int($zoom_recordings)) {
-                                    $DB->update_record('event', (object)['id' => $value->id, 'recording_created' => 1]);
-                                    mtrace('Recordings updated for event id: '. $recordings->id. ' and uuid: '. $recordings->uuid);
+                            if (!empty($recordings) && !empty($recordings->recording_files)) {
+                                $all_inserted = true;
+                                foreach ($recordings->recording_files as $rec) {
+                                    $record = new stdClass();
+                                    $record->meeting_id = $recordings->id;
+                                    $record->uuid = $recordings->uuid;
+                                    $record->play_url = $rec->play_url;
+                                    $record->download_url = $rec->download_url . '?access_token=' . $recordings->download_access_token;
+                                    $record->start_time = $rec->recording_start;
+                                    $record->end_time = $rec->recording_end;
+                                    $record->status = $rec->status;
+
+                                    $inserted = $DB->insert_record('zoom_recordings', $record);
+                                    if (!is_int($inserted)) {
+                                        mtrace("Failed to insert recording for meeting UUID: {$recordings->uuid}");
+                                        $all_inserted = false;
+                                    }
+                                }
+
+                                if ($all_inserted) {
+                                    $DB->update_record('event', (object)[
+                                        'id' => $event->id,
+                                        'recording_created' => 1
+                                    ]);
+                                    mtrace("Recordings updated for event ID: {$event->id} and UUID: {$recordings->uuid}");
                                 } else {
-                                    mtrace('Recordings could not be inserted for event id: '. $value->id. ' and uuid: '. $recordings->uuid);
+                                    mtrace("Some recordings could not be inserted for event ID: {$event->id} and UUID: {$recordings->uuid}");
                                 }
                             } else {
-                                mtrace('No recordings found for the meeting_id: '. $value->meeting_id);
+                                mtrace('Recording already exist for meeting: ' . $value->meeting_id . 'and uuid: ' . $uuid);
                             }
-                        } else {
-                            mtrace('Recording already exist for meeting: '. $value->meeting_id . 'and uuid: '. $uuid);
                         }
+
                     } catch (\moodle_exception $error) {
                         mtrace("Recording skipped for uuid: {$uuid} and meeting_id: {$value->meeting_id} because of the error {$error}");
                     }

--- a/cli/update_meeting_recordings.php
+++ b/cli/update_meeting_recordings.php
@@ -134,23 +134,33 @@ foreach (keyByMeetingId($events) as $meeting_id => $events) {
             try {
                 $recordings = $service->get_meeting_recording($uuid);
 
-                if (!empty($recordings) && !empty($recordings->recording_files[0])) {
-                    //Get only the first recording file
-                    $rec = $recordings->recording_files[0];
-                    $record = new stdClass();
-                    $record->meeting_id = $recordings->id;
-                    $record->uuid = $recordings->uuid;
-                    $record->play_url = $rec->play_url;
-                    $record->download_url = $rec->download_url . '?access_token=' . $recordings->download_access_token;
-                    $record->start_time = $rec->recording_start;
-                    $record->end_time = $rec->recording_end;
-                    $record->status = $rec->status;
-                    $zoom_recordings = $DB->insert_record('zoom_recordings', $record);
-                    if (is_int($zoom_recordings)) {
-                        $DB->update_record('event', (object)['id' => $event->id, 'recording_created' => 1]);
-                        mtrace('Recordings updated for event id: ' . $event->id . ' and uuid: ' . $recordings->uuid);
+                if (!empty($recordings) && !empty($recordings->recording_files)) {
+                    $all_inserted = true;
+                    foreach ($recordings->recording_files as $rec) {
+                        $record = new stdClass();
+                        $record->meeting_id = $recordings->id;
+                        $record->uuid = $recordings->uuid;
+                        $record->play_url = $rec->play_url;
+                        $record->download_url = $rec->download_url . '?access_token=' . $recordings->download_access_token;
+                        $record->start_time = $rec->recording_start;
+                        $record->end_time = $rec->recording_end;
+                        $record->status = $rec->status;
+
+                        $inserted = $DB->insert_record('zoom_recordings', $record);
+                        if (!is_int($inserted)) {
+                            mtrace("Failed to insert recording for meeting UUID: {$recordings->uuid}");
+                            $all_inserted = false;
+                        }
+                    }
+
+                    if ($all_inserted) {
+                        $DB->update_record('event', (object)[
+                            'id' => $event->id,
+                            'recording_created' => 1
+                        ]);
+                        mtrace("Recordings updated for event ID: {$event->id} and UUID: {$recordings->uuid}");
                     } else {
-                        mtrace('Recordings could not be inserted for event id: ' . $event->id . ' and uuid: ' . $recordings->uuid);
+                        mtrace("Some recordings could not be inserted for event ID: {$event->id} and UUID: {$recordings->uuid}");
                     }
                 } else {
                     mtrace('No recordings found for the meeting_id: ' . $meeting_id);


### PR DESCRIPTION
### Summary
This update enhances the Zoom recording ingestion logic to handle cases where a single meeting instance has multiple recording files (e.g., due to a pause/resume or host reconnect scenario).

### Changes
- Loops through all `recording_files` returned by the Zoom API.
- Updates the related `event` row with `recording_created = 1` after successful inserts.

### Why This Is Needed
Previously, only the first recording file was stored, which led to data loss when meetings had multiple recordings. This change ensures all relevant recordings are saved for complete event coverage.

### Notes
- Assumes `zoom_recordings` table allows multiple entries per meeting UUID.
- No filtering is applied to file types — all returned recording files are saved.
