### PR TITLE
Fix: Class not found error

### DIFF
--- a/classes/task/insert_recordings.php
+++ b/classes/task/insert_recordings.php
@@ -69,7 +69,7 @@ class insert_recordings extends \core\task\scheduled_task
                             if (!empty($recordings) && !empty($recordings->recording_files)) {
                                 $all_inserted = true;
                                 foreach ($recordings->recording_files as $rec) {
-                                    $record = new stdClass();
+                                    $record = new \stdClass();
                                     $record->meeting_id = $recordings->id;
                                     $record->uuid = $recordings->uuid;
                                     $record->play_url = $rec->play_url;

--- a/cli/update_meeting_recordings.php
+++ b/cli/update_meeting_recordings.php
@@ -137,7 +137,7 @@ foreach (keyByMeetingId($events) as $meeting_id => $events) {
                 if (!empty($recordings) && !empty($recordings->recording_files)) {
                     $all_inserted = true;
                     foreach ($recordings->recording_files as $rec) {
-                        $record = new \stdClass();
+                        $record = new stdClass();
                         $record->meeting_id = $recordings->id;
                         $record->uuid = $recordings->uuid;
                         $record->play_url = $rec->play_url;

--- a/cli/update_meeting_recordings.php
+++ b/cli/update_meeting_recordings.php
@@ -137,7 +137,7 @@ foreach (keyByMeetingId($events) as $meeting_id => $events) {
                 if (!empty($recordings) && !empty($recordings->recording_files)) {
                     $all_inserted = true;
                     foreach ($recordings->recording_files as $rec) {
-                        $record = new stdClass();
+                        $record = new \stdClass();
                         $record->meeting_id = $recordings->id;
                         $record->uuid = $recordings->uuid;
                         $record->play_url = $rec->play_url;


### PR DESCRIPTION
Summary:
Updated instantiations of stdClass to use the global namespace (\stdClass) to ensure compatibility and prevent conflicts when used within namespaced code.

Reason for Change:
In namespaced contexts, using new stdClass() without the leading backslash can cause PHP to look for stdClass within the current namespace, which may not exist. This can lead to runtime errors or unexpected behavior.