### PR TITLE
Fix Zoom meeting registrant approval flow and timestamp handling

### DIFF
--- a/classes/task/add_meeting_registrant.php
+++ b/classes/task/add_meeting_registrant.php
@@ -78,7 +78,7 @@ class add_meeting_registrant extends \core\task\scheduled_task
                                     $insertRegistrant['start_time'] = "$response->start_time";
                                     $insertRegistrant['topic'] = "$response->topic";
                                     $insertRegistrant['status'] = 'PENDING';
-                                    $insertRegistrant['created_at'] = date('Y-m-d H:i:s');
+                                    $insertRegistrant['created_at'] = time();
 
                                     $DB->insert_record('zoom_meeting_registrant', $insertRegistrant);
 

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -416,5 +416,21 @@ function xmldb_zoom_upgrade($oldversion) {
 
         upgrade_mod_savepoint(true, 20250723000, 'zoom');
     }
+
+    if ($oldversion < 20250916100) {
+        $queryToAddUnixColumn = "ALTER TABLE {zoom_meeting_registrant} ADD COLUMN created_at_unix BIGINT(10)";
+        $DB->execute($queryToAddUnixColumn);
+
+        $queryToUpdateExistingValue = "UPDATE {zoom_meeting_registrant} SET created_at_unix = UNIX_TIMESTAMP(created_at)";
+        $DB->execute($queryToUpdateExistingValue);
+
+        $dropColumnOfDatetime = "ALTER TABLE {zoom_meeting_registrant} DROP COLUMN created_at";
+        $DB->execute($dropColumnOfDatetime);
+
+        $updateColumnNameCreatedAt = "ALTER TABLE {zoom_meeting_registrant} CHANGE created_at_unix created_at BIGINT(10) NOT NULL";
+        $DB->execute($updateColumnNameCreatedAt);
+
+        upgrade_mod_savepoint(true, 20250916100, 'zoom');
+    }
     return true;
 }

--- a/helperfunctions.php
+++ b/helperfunctions.php
@@ -73,15 +73,10 @@ function updateMeetingRegistrants($service, $DB, $registrants, $meetingID) {
             $requestPayload = [];
             $requestPayload["action"] = "approve";
             $requestPayload["registrants"] = $registrants;
-           
-            $updateMeetingRegistrantStatus = $service->update_registrants_status($requestPayload, $meetingID);
 
-            if ($updateMeetingRegistrantStatus == 204) {
-                syncRegistrantDetails($service, $DB, $meetingID);
-            } else {
-                mtrace('update_registrants_status API returned status code as: ' . $updateMeetingRegistrantStatus);
-            }
-            
+            $service->update_registrants_status($requestPayload, $meetingID);
+            syncRegistrantDetails($service, $DB, $meetingID);
+
         } catch (\moodle_exception $error) {
             mtrace('Update registrant status failed: ' . $error);
         }

--- a/helperfunctions.php
+++ b/helperfunctions.php
@@ -87,7 +87,7 @@ function updateMeetingRegistrants($service, $DB, $registrants, $meetingID) {
 
 function syncRegistrantDetails($service, $DB, $meetingID) {
     try {
-        $meetingRegistrantList = $service->get_meeting_registrants($meetingID);
+        $meetingRegistrantList = $service->get_meeting_registrants($meetingID, '');
         foreach ($meetingRegistrantList->registrants as $data) {
             if ($data->status == "approved") {
                 $join_url = urlencode($data->join_url);

--- a/helperfunctions.php
+++ b/helperfunctions.php
@@ -73,7 +73,6 @@ function updateMeetingRegistrants($service, $DB, $registrants, $meetingID) {
             $requestPayload = [];
             $requestPayload["action"] = "approve";
             $requestPayload["registrants"] = $registrants;
-            $requestPayload = json_encode($requestPayload);
            
             $updateMeetingRegistrantStatus = $service->update_registrants_status($requestPayload, $meetingID);
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 20250723000;
+$plugin->version = 20250916100;
 $plugin->release = 'v3.0.1';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR addresses several issues in the Zoom integration tasks:

- Use epoch timestamps for created_at
    Updated the created_at column from DATETIME to epoch timestamp format to standardise time storage.

- Correct request body for Zoom API
     Removed the extra json_encode() before calling the Zoom API, since make_call() already encodes the payload. This ensures valid JSON is sent.

- Simplify status handling for update_registrants_status
    Removed the status code check after update_registrants_status because the method does not return an HTTP status code. Errors are now handled in the existing catch block.

- Added missing parameter for get_meeting_registrants()
     Included the second argument required by the API to correctly retrieve registrants.

These changes fix the approval of Zoom meeting registrants