### PR TITLE
Replace decoding with encoding for meeting ID in Zoom recording API call

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -1085,7 +1085,7 @@ class mod_zoom_webservice {
     public function get_meeting_recording($meeting_id)
     {
         if (preg_match('#^/{1,2}#', $meeting_id)) {
-            $encoded_meeting_id = rawurldecode(rawurldecode($meeting_id));
+            $encoded_meeting_id = rawurlencode(rawurlencode($meeting_id));
         } else {
             $encoded_meeting_id = $meeting_id;
         }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 20251011000;
-$plugin->release = 'v3.0.2';
+$plugin->version = 20251113000;
+$plugin->release = 'v3.0.3';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 900; // secs


### PR DESCRIPTION
This pull request updates the Zoom API request logic to correctly handle meeting IDs that begin with `/` or `//`.
Previously, such meeting IDs led to malformed URLs and API failures because they were **decoded instead of being properly encoded.**

### **Changes**

* Replaced `rawurldecode()` calls with double `rawurlencode()` to ensure correct URL encoding.

### **Impact**

* Fixes issues where recordings for certain meetings were not fetched despite being visible in the Zoom portal.
* Prevents malformed API requests and ensures consistent retrieval of Zoom meeting recordings.