### PR TITLE
Hide/Unveil recording fails when play_url is NULL

### DIFF
--- a/hiderecording.php
+++ b/hiderecording.php
@@ -14,12 +14,16 @@ $meeting_id = $_REQUEST['meeting_id'];
 $play_url = $_REQUEST['play_url'] ?? null;
 $download_url = $_REQUEST['download_url'] ?? null;
 
-if (is_null($play_url)) {
-    $hideMeeting = "UPDATE mdl_zoom_recordings SET hide_recording = 1 WHERE meeting_id = $meeting_id AND download_url = '$download_url'";
-    $DB->execute($hideMeeting);
+if (is_null($play_url) || empty($play_url)) {
+    $DB->execute(
+            "UPDATE {zoom_recordings} SET hide_recording = 1 WHERE meeting_id = :meeting_id AND download_url = :download_url",
+            ['meeting_id' => $meeting_id, 'download_url' => $download_url]
+    );
 } else {
-    $hideMeeting = "UPDATE mdl_zoom_recordings SET hide_recording = 1 WHERE meeting_id = $meeting_id AND play_url = '$play_url'";
-    $DB->execute($hideMeeting);
+    $DB->execute(
+            "UPDATE mdl_zoom_recordings SET hide_recording = 1 WHERE meeting_id = $meeting_id AND play_url = :play_url",
+            ['play_url' => $play_url]
+    );
 }
 ?>
 

--- a/hiderecording.php
+++ b/hiderecording.php
@@ -16,7 +16,7 @@ $download_url = $_REQUEST['download_url'] ?? null;
 
 if (is_null($play_url) || empty($play_url)) {
     $DB->execute(
-            "UPDATE {zoom_recordings} SET hide_recording = 1 WHERE meeting_id = :meeting_id AND download_url = :download_url",
+            "UPDATE mdl_zoom_recordings SET hide_recording = 1 WHERE meeting_id = :meeting_id AND download_url = :download_url",
             ['meeting_id' => $meeting_id, 'download_url' => $download_url]
     );
 } else {

--- a/unveilrecording.php
+++ b/unveilrecording.php
@@ -16,7 +16,7 @@ $download_url = $_REQUEST['download_url'] ?? null;
 
 if(is_null($play_url) || empty($play_url)) {
     $DB->execute(
-            "UPDATE {zoom_recordings} SET hide_recording = 0 WHERE meeting_id = :meeting_id AND download_url = :download_url",
+            "UPDATE mdl_zoom_recordings SET hide_recording = 0 WHERE meeting_id = :meeting_id AND download_url = :download_url",
             ['meeting_id' => $meeting_id, 'download_url' => $download_url]
     );
 } else {

--- a/unveilrecording.php
+++ b/unveilrecording.php
@@ -12,10 +12,19 @@ list($course, $cm, $zoom) = zoom_get_instance_setup();
 
 $meeting_id = $_REQUEST['meeting_id'];
 $play_url = $_REQUEST['play_url'] ?? null;
+$download_url = $_REQUEST['download_url'] ?? null;
 
-$unveil_recording = "UPDATE mdl_zoom_recordings SET hide_recording = 0 WHERE meeting_id = $meeting_id AND play_url = '$play_url'";
-$DB->execute($unveil_recording);
-
+if(is_null($play_url) || empty($play_url)) {
+    $DB->execute(
+            "UPDATE {zoom_recordings} SET hide_recording = 0 WHERE meeting_id = :meeting_id AND download_url = :download_url",
+            ['meeting_id' => $meeting_id, 'download_url' => $download_url]
+    );
+} else {
+    $DB->execute(
+            "UPDATE mdl_zoom_recordings SET hide_recording = 0 WHERE meeting_id = $meeting_id AND play_url = :play_url",
+            ['play_url' => $play_url]
+    );
+}
 ?>
 
 <script>

--- a/view.php
+++ b/view.php
@@ -196,7 +196,7 @@ if (!empty($records)) {
             $disply_date = date_format($created_date, 'm-d-Y');
             $display .= '<br>&nbsp;' . $disply_date . '<br>' . '&nbsp;<a target="_blank" href="' . $play_urls . '">View |</a>&nbsp;<a target="_blank" href="' . $download_urls . '">Download</a> ';
             if ($iszoommanager) {
-                $display .= '|&nbsp;<a target="_self" href="hiderecording.php?id=' . $cm->id . '&meeting_id=' . $zoom->meeting_id . '&play_url=' . $value->play_url . '" onclick="location.reload()">Hide</a>';
+                $display .= '|&nbsp;<a target="_self" href="hiderecording.php?id=' . $cm->id . '&meeting_id=' . $zoom->meeting_id . '&play_url=' . $value->play_url . '&download_url=' . $value->download_url . '" onclick="location.reload()">Hide</a>';
             }
         }
         $display .= '</br>';
@@ -257,7 +257,9 @@ if ($iszoommanager) {
             $date =  zoom_convert_date_time(strtotime($record->start_time), 'jS F Y, g:i A') . ' ' . usertimezone();
             $created_date = date_create($date);
             $display_date = date_format($created_date, 'm-d-Y');
-            $displayHidden .= '<br>&nbsp;'.$display_date.'<br>&nbsp;<a target="_self" href="'.$record->play_url.'">View</a> | &nbsp;<a target="_blank" href="'.$download_urls.'">Download</a> | &nbsp; <a target="_self" href="unveilrecording.php?id='.$cm->id.'&meeting_id='.$zoom->meeting_id .'&play_url='.$record->play_url.'">Unveil</a>';
+            $displayHidden .= '<br>&nbsp;'.$display_date.'<br>&nbsp;<a target="_self" href="'.$record->play_url.'">View</a> | 
+                                   &nbsp;<a target="_blank" href="'.$record->download_url.'">Download</a> | 
+                                   &nbsp; <a target="_self" href="unveilrecording.php?id='.$cm->id.'&meeting_id='.$zoom->meeting_id .'&play_url='.$record->play_url. '&download_url='.$record->download_url.'">Unveil</a>';
         }
 
         $table->data[] = array(get_string('hidden_recording', 'zoom'), $displayHidden);


### PR DESCRIPTION
This PR fixes the issue where recordings with a NULL  play_url could not be hidden or unveiled.

**Issue:** 
- Earlier, when the recording had a NULL play_url, Moodle converted it into an empty string in the GET request.
- Because the hide/unveil logic only checked is_null($play_url) and the request did not send the download_url, the SQL update matched 0 rows.
- As a result, clicking Hide or Unveil simply refreshed the page without updating the record.

**Solution:**
  - Added download_url as a required parameter in both Hide + Unveil links.
  - Treating NULL play_url consistently
  - Updating SQL to use Moodle parameter binding
  - Aligning Hide and Unveil logic

**Test case:**
1) **Test Case: Recording with NULL play_url (Transcript)**
1. Go to **Zoom Web Portal → Settings → Recording → Advanced cloud recording settings**.
2. Enable:
   - Save closed caption as a VTT file
3. Create a Zoom meeting from Moodle.
4. Start and join the meeting.
5. During the meeting:
   - Enable **Live Captions**.
   - Speak for a few minutes to generate captions.
   - *(Optional)* Share screen to create multiple recordings.
6. End the meeting.
7. Wait 10–60 minutes for Zoom to process recordings.
8. Run Moodle cron / fetch Zoom recordings.
9. Verify fetched recordings:
   - MP4 recordings have a valid `play_url`.
   - Transcript recording (`file_type = VTT`) has `play_url = NULL`.
10. In Moodle:
    - Click **Hide** on the transcript recording.
    - Click **Unhide** on the transcript recording.
    -

**2) Test case to test the hide and unveil**

1) Create a Zoom meeting that generates multiple recordings.
2) Update one of the recordings so that its play_url is set to NULL (for testing purposes).
3) Test the following scenario

Scenario ID | Play URL | Download URL | Action | Expected Behavior
-- | -- | -- | -- | --
S1 | NULL | Present | View |works as expected
S2 | NULL | Present | Download | works as expected
S3 | NULL | Present | Hide | hide the recording
S4 | NULL | Present | Unhide | Should unhide.
S5 | present | Present | Hide |works as expected

