### PR TITLE
Fix: Zoom message provider constants for Moodle 4.5 compatibility

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -8,19 +8,19 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$messageproviders = array(
+$messageproviders = [
     // Notify users about session creation.
-    'session_notification' => array(
-        'defaults' => array(
-            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF
-        )
-    ),
+    'session_notification' => [
+        'defaults' => [
+            'email' => MESSAGE_DEFAULT_ENABLED,
+        ],
+    ],
 
-    // Send remainder about the session.
-    'session_reminder' => array(
-        'defaults' => array(
-            'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN,
-            'email' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF
-        )
-    )
-);
+    // Send a reminder about the session.
+    'session_reminder' => [
+        'defaults' => [
+            'popup' => MESSAGE_DEFAULT_ENABLED,
+            'email' => MESSAGE_DEFAULT_ENABLED,
+        ],
+    ],
+];

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 20251216000;
-$plugin->release = 'v3.0.4';
+$plugin->version = 20251218001;
+$plugin->release = 'v3.0.5';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->cron = 900; // secs


### PR DESCRIPTION
### Summary
Updated `mod/zoom/db/messages.php` to replace deprecated messaging constants with Moodle 4.5–compatible defaults.

### Why
Moodle 4.4+ removed the following constants:
- MESSAGE_DEFAULT_ON
- MESSAGE_DEFAULT_LOGGEDIN
- MESSAGE_DEFAULT_LOGGEDOFF

This caused plugin upgrade failures with:
`Undefined constant MESSAGE_DEFAULT_*`

### How
- Replaced deprecated constants with `MESSAGE_DEFAULT_ENABLED`
- Aligned message provider definitions with Moodle 4.5 API

### Testing
- Purged caches
- Ran plugin upgrade via Admin → Notifications
- Verified Zoom message providers appear in notification settings
