### PR TITLE
Zoom recording fetch in CLI and scheduled job to support allowed file types

### DIFF
--- a/classes/task/insert_recordings.php
+++ b/classes/task/insert_recordings.php
@@ -45,6 +45,14 @@ class insert_recordings extends \core\task\scheduled_task
                 AND mz.deleted_at IS NULL 
                 AND FROM_UNIXTIME(e.endtime) BETWEEN NOW() - interval 2 day and NOW()";
 
+        $allowedRecordingType = get_config('mod_zoom', 'recording_file_types');
+
+        if (!empty($allowedtypes) && is_array($allowedtypes)) {
+            $allowedRecordingType = array_keys($allowedtypes);
+        } else {
+            $allowedRecordingType = ['mp4'];
+        }
+
         $zoom_events = $DB->get_records_sql($sql);
         $service = new \mod_zoom_webservice();
 
@@ -69,6 +77,14 @@ class insert_recordings extends \core\task\scheduled_task
                             if (!empty($recordings) && !empty($recordings->recording_files)) {
                                 $all_inserted = true;
                                 foreach ($recordings->recording_files as $rec) {
+
+                                    $fileType = strtolower($rec->file_type ?? '');
+
+                                    if (!in_array($fileType, $allowedRecordingType, true)) {
+                                        mtrace("Skipping recording file type {$fileType} for UUID: {$uuid}");
+                                        continue;
+                                    }
+
                                     $record = new \stdClass();
                                     $record->meeting_id = $recordings->id;
                                     $record->uuid = $recordings->uuid;
@@ -80,7 +96,7 @@ class insert_recordings extends \core\task\scheduled_task
 
                                     $inserted = $DB->insert_record('zoom_recordings', $record);
                                     if (!is_int($inserted)) {
-                                        mtrace("Failed to insert recording for meeting UUID: {$recordings->uuid}");
+                                        mtrace("Failed to insert ${fileType} recording for meeting UUID: {$recordings->uuid}");
                                         $all_inserted = false;
                                     }
                                 }

--- a/classes/task/insert_recordings.php
+++ b/classes/task/insert_recordings.php
@@ -45,19 +45,19 @@ class insert_recordings extends \core\task\scheduled_task
                 AND mz.deleted_at IS NULL 
                 AND FROM_UNIXTIME(e.endtime) BETWEEN NOW() - interval 2 day and NOW()";
 
-        $allowedRecordingType = get_config('mod_zoom', 'recording_file_types');
-
-        if (!empty($allowedtypes) && is_array($allowedtypes)) {
-            $allowedRecordingType = array_keys($allowedtypes);
-        } else {
-            $allowedRecordingType = ['mp4'];
+        $allowedRecordingType = ['mp4'];
+        $additionalTypes = get_config('mod_zoom', 'recording_file_types');
+        if (!empty($additionalTypes)) {
+            $additionalTypes = json_decode($additionalTypes, true);
+            if (is_array($additionalTypes)) {
+                $allowedRecordingType = array_merge($allowedRecordingType, array_keys($additionalTypes));
+            }
         }
 
         $zoom_events = $DB->get_records_sql($sql);
         $service = new \mod_zoom_webservice();
 
         foreach ($zoom_events as $value) {
-            $zoom_recordings = null;
             try {
                 $this->disable_download_in_stream($value->meeting_id);
 
@@ -103,12 +103,12 @@ class insert_recordings extends \core\task\scheduled_task
 
                                 if ($all_inserted) {
                                     $DB->update_record('event', (object)[
-                                        'id' => $event->id,
+                                        'id' => $value->id,
                                         'recording_created' => 1
                                     ]);
-                                    mtrace("Recordings updated for event ID: {$event->id} and UUID: {$recordings->uuid}");
+                                    mtrace("Recordings updated for event ID: {$value->id} and UUID: {$recordings->uuid}");
                                 } else {
-                                    mtrace("Some recordings could not be inserted for event ID: {$event->id} and UUID: {$recordings->uuid}");
+                                    mtrace("Some recordings could not be inserted for event ID: {$value->id} and UUID: {$recordings->uuid}");
                                 }
                             } else {
                                 mtrace('Recording already exist for meeting: ' . $value->meeting_id . 'and uuid: ' . $uuid);

--- a/cli/update_meeting_recordings.php
+++ b/cli/update_meeting_recordings.php
@@ -95,12 +95,14 @@ $service = new mod_zoom_webservice();
  * Allowed recording file types (admin setting)
  * ---------------------------------------------------------
  */
-$allowedtypes = get_config('mod_zoom', 'recording_file_types');
 
-if (empty($allowedtypes)) {
-    $allowedtypes = ['mp4'];
-} else {
-    $allowedtypes = array_map('strtolower', array_keys($allowedtypes));
+$allowedtypes = ['mp4'];
+$additionalTypes = get_config('mod_zoom', 'recording_file_types');
+if (!empty($additionalTypes)) {
+    $additionalTypes = json_decode($additionalTypes, true);
+    if (is_array($additionalTypes)) {
+        $allowedtypes = array_merge($allowedtypes, array_map('strtolower', array_keys($additionalTypes)));
+    }
 }
 
 $trace->output('Allowed recording file types: ' . implode(', ', $allowedtypes));

--- a/cli/update_meeting_recordings.php
+++ b/cli/update_meeting_recordings.php
@@ -23,20 +23,20 @@ define('CLI_SCRIPT', true);
 require(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/clilib.php');
 
-// Now get cli options.
+// CLI options.
 list($options, $unrecognized) = cli_get_params(
-    array(
+    [
         'help' => false,
         'meeting_id' => false,
-    ),
-    array(
-        'h' => 'help'
-    )
+    ],
+    [
+        'h' => 'help',
+        'm' => 'meeting_id',
+    ]
 );
 
 if ($unrecognized) {
-    $unrecognized = implode("\n  ", $unrecognized);
-    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+    cli_error(get_string('cliunknowoption', 'admin', implode("\n  ", $unrecognized)));
 }
 
 if ($options['help']) {
@@ -64,13 +64,11 @@ if (!empty($options['meeting_id'])) {
                 AND mz.deleted_at IS NULL 
                 AND mz.meeting_id = ?
               AND e.endtime < UNIX_TIMESTAMP(NOW())";
-
     try {
-        $events = $DB->get_records_sql($sql, array($options['meeting_id']));
+        $events = $DB->get_records_sql($sql, [$options['meeting_id']]);
     } catch (Exception $e) {
         $trace->output('Exception: ' . $e->getMessage(), 1);
     }
-
 } else {
     $sql = "SELECT e.*, mz.meeting_id, mz.auto_recording, mz.webinar 
               FROM mdl_event as e
@@ -90,7 +88,22 @@ if (empty($events)) {
     cli_error('No meetings found to update.');
 }
 
-$service = new \mod_zoom_webservice();
+$service = new mod_zoom_webservice();
+
+/**
+ * ---------------------------------------------------------
+ * Allowed recording file types (admin setting)
+ * ---------------------------------------------------------
+ */
+$allowedtypes = get_config('mod_zoom', 'recording_file_types');
+
+if (empty($allowedtypes)) {
+    $allowedtypes = ['mp4'];
+} else {
+    $allowedtypes = array_map('strtolower', array_keys($allowedtypes));
+}
+
+$trace->output('Allowed recording file types: ' . implode(', ', $allowedtypes));
 
 foreach (keyByMeetingId($events) as $meeting_id => $events) {
 
@@ -120,35 +133,54 @@ foreach (keyByMeetingId($events) as $meeting_id => $events) {
         }
 
         foreach ($uuids as $uuid) {
-            //Check if the recordings exists already
-            if ($DB->get_record('zoom_recordings',
-                array('meeting_id' => $meeting_id,
-                    'uuid' => $uuid))
-            ) {
-                $DB->update_record('event', (object)['id' => $event->id, 'recording_created' => 1]);
-                $trace->output(sprintf('Skipping recording update as it already exists for event_id: %d', $event->id));
-                $trace->output(sprintf('---------------------------------------------'));
-                continue;
-            }
 
             try {
+                if ($DB->get_record('zoom_recordings', [
+                    'meeting_id' => $meeting_id,
+                    'uuid' => $uuid
+                ])) {
+                    $DB->update_record('event', (object)[
+                        'id' => $event->id,
+                        'recording_created' => 1
+                    ]);
+                    $trace->output(sprintf('Skipping recording update as it already exists for event_id: %d', $event->id));
+                    $trace->output(sprintf('---------------------------------------------'));
+                    continue;
+                }
+
                 $recordings = $service->get_meeting_recording($uuid);
 
                 if (!empty($recordings) && !empty($recordings->recording_files)) {
+
                     $all_inserted = true;
+
                     foreach ($recordings->recording_files as $rec) {
+
+                        $filetype = strtolower($rec->file_type ?? '');
+
+                        if (!in_array($filetype, $allowedtypes, true)) {
+                            $trace->output(
+                                "Skipping {$filetype} recording for uuid: {$uuid}",
+                                1
+                            );
+                            continue;
+                        }
+
                         $record = new stdClass();
                         $record->meeting_id = $recordings->id;
                         $record->uuid = $recordings->uuid;
-                        $record->play_url = $rec->play_url;
-                        $record->download_url = $rec->download_url . '?access_token=' . $recordings->download_access_token;
-                        $record->start_time = $rec->recording_start;
-                        $record->end_time = $rec->recording_end;
-                        $record->status = $rec->status;
+                        $record->play_url = $rec->play_url ?? null;
+                        $record->download_url =
+                            $rec->download_url . '?access_token=' . $recordings->download_access_token;
+                        $record->start_time = $rec->recording_start ?? null;
+                        $record->end_time = $rec->recording_end ?? null;
+                        $record->status = $rec->status ?? null;
+                        $record->file_type = $filetype;
 
                         $inserted = $DB->insert_record('zoom_recordings', $record);
+
                         if (!is_int($inserted)) {
-                            mtrace("Failed to insert recording for meeting UUID: {$recordings->uuid}");
+                            mtrace("Failed to insert {$filetype} recording for uuid: {$uuid}");
                             $all_inserted = false;
                         }
                     }
@@ -158,21 +190,31 @@ foreach (keyByMeetingId($events) as $meeting_id => $events) {
                             'id' => $event->id,
                             'recording_created' => 1
                         ]);
-                        mtrace("Recordings updated for event ID: {$event->id} and UUID: {$recordings->uuid}");
+                        mtrace(
+                            "Recordings updated for event_id: {$event->id} and uuid: {$uuid}"
+                        );
                     } else {
-                        mtrace("Some recordings could not be inserted for event ID: {$event->id} and UUID: {$recordings->uuid}");
+                        mtrace(
+                            "Some recordings could not be inserted for event_id: {$event->id} and uuid: {$uuid}"
+                        );
                     }
+
                 } else {
-                    mtrace('No recordings found for the meeting_id: ' . $meeting_id);
+                    mtrace(
+                        "No recordings found for meeting_id: {$meeting_id} and uuid: {$uuid}"
+                    );
                 }
-            } catch (\moodle_exception $error) {
-                mtrace('Recordings could not be updated: ' . $error);
+
+            } catch (moodle_exception $error) {
+                mtrace(
+                    "Recording skipped for uuid: {$uuid} and meeting_id: {$meeting_id} " .
+                    "because of error: {$error->getMessage()}"
+                );
             }
         }
-        $trace->output(sprintf('---------------------------------------------'));
-    }
 
-    $trace->output(sprintf('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'));
+        $trace->output('---------------------------------------------');
+    }
 }
 
 /**

--- a/lang/en/zoom.php
+++ b/lang/en/zoom.php
@@ -255,6 +255,15 @@ $string['trackingfields'] = 'Tracking fields';
 $string['trackingfields_help'] = 'Enter the tracking field name(s)/label(s), separated by commas, to enable for Zoom activities.';
 $string['trackingfields_recommendedvalues'] = 'Recommended values: ';
 
+$string['recordingfiletypes'] = 'Zoom recording file types to store';
+$string['recordingfiletypes_desc'] =
+    'Select which Zoom recording file types should be downloaded and stored when fetching recordings.';
+
+$string['recordingtype_video'] = 'Video recordings (MP4)';
+$string['recordingtype_audio'] = 'Audio-only recordings (M4A)';
+$string['recordingtype_chat']  = 'Chat transcripts (TXT)';
+$string['recordingtype_cc']    = 'Closed captions (VTT)';
+
 // Email
 $string['msg_header'] = 'Dear {$a},';
 $string['msg_attendee_desc'] = 'You have been requested to attend the following session.';

--- a/lang/en/zoom.php
+++ b/lang/en/zoom.php
@@ -255,9 +255,9 @@ $string['trackingfields'] = 'Tracking fields';
 $string['trackingfields_help'] = 'Enter the tracking field name(s)/label(s), separated by commas, to enable for Zoom activities.';
 $string['trackingfields_recommendedvalues'] = 'Recommended values: ';
 
-$string['recordingfiletypes'] = 'Zoom recording file types to store';
+$string['recordingfiletypes'] = 'Additional Zoom recording file types to store';
 $string['recordingfiletypes_desc'] =
-    'Select which Zoom recording file types should be downloaded and stored when fetching recordings.';
+	'Select additional Zoom recording file types to download and store when fetching recordings. Note: MP4 video recordings are always fetched and stored automatically.';
 
 $string['recordingtype_video'] = 'Video recordings (MP4)';
 $string['recordingtype_audio'] = 'Audio-only recordings (M4A)';

--- a/settings.php
+++ b/settings.php
@@ -157,19 +157,22 @@ if ($ADMIN->fulltree) {
     $defaulttrackingfields->set_updatedcallback('mod_zoom_update_tracking_fields');
 
     $options = [
-        'mp4' => get_string('recordingtype_video', 'mod_zoom'),
         'm4a' => get_string('recordingtype_audio', 'mod_zoom'),
         'txt' => get_string('recordingtype_chat', 'mod_zoom'),
         'vtt' => get_string('recordingtype_cc', 'mod_zoom')
     ];
 
-    $settings->add(new admin_setting_configmulticheckbox(
+
+    $recordingsetting = new admin_setting_configmulticheckbox(
         'mod_zoom/recording_file_types',
         get_string('recordingfiletypes', 'mod_zoom'),
         get_string('recordingfiletypes_desc', 'mod_zoom'),
-        ['mp4'],
+        [],
         $options
-    ));
+    );
+
+    $settings->add($recordingsetting);
+
 
     $settings->add($defaulttrackingfields);
 }

--- a/settings.php
+++ b/settings.php
@@ -155,5 +155,21 @@ if ($ADMIN->fulltree) {
         get_string('trackingfields', 'mod_zoom'),
         get_string('trackingfields_help', 'mod_zoom'), '');
     $defaulttrackingfields->set_updatedcallback('mod_zoom_update_tracking_fields');
+
+    $options = [
+        'mp4' => get_string('recordingtype_video', 'mod_zoom'),
+        'm4a' => get_string('recordingtype_audio', 'mod_zoom'),
+        'txt' => get_string('recordingtype_chat', 'mod_zoom'),
+        'vtt' => get_string('recordingtype_cc', 'mod_zoom')
+    ];
+
+    $settings->add(new admin_setting_configmulticheckbox(
+        'mod_zoom/recording_file_types',
+        get_string('recordingfiletypes', 'mod_zoom'),
+        get_string('recordingfiletypes_desc', 'mod_zoom'),
+        ['mp4'],
+        $options
+    ));
+
     $settings->add($defaulttrackingfields);
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 20251218001;
+$plugin->version = 20251218002;
 $plugin->release = 'v3.0.5';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 20251218002;
+$plugin->version = 20260127002;
 $plugin->release = 'v3.0.5';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
### Summary
This PR updates the Zoom plugin’s scheduled task and CLI command responsible for fetching meeting recordings to correctly respect admin-configured allowed recording file types.

### Key Changes
- Added support for filtering Zoom recordings based on the configured allowed file types, with `MP4` as default type so that user dont have option to ignore `MP4`
- Ensured consistent behavior across:
   - Scheduled job (cron)
   - CLI command for manual recording sync
